### PR TITLE
🌱 Bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/workflow-templates/security-scan.yml
+++ b/workflow-templates/security-scan.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary
- Upgrades `aquasecurity/trivy-action` to v0.35.0
- Pin by commit hash per repo GHA discipline: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`

## Related issue(s)
Related: kubestellar/infra#129

## Test plan
- [ ] CI passes on this PR

---
Generated with [Claude Code](https://claude.com/claude-code)